### PR TITLE
Added ability to handle empty lists of keys to DataLoaderBase

### DIFF
--- a/src/Core.Tests/DataLoaderBaseTests.cs
+++ b/src/Core.Tests/DataLoaderBaseTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GreenDonut.FakeDataLoaders;
 using Xunit;
@@ -54,6 +56,45 @@ namespace GreenDonut
             Assert.Null(Record.Exception(verify));
         }
 
+        #endregion
+
+        #region bugfix - Allow Empty Lists To be loaded
+
+
+        [Fact(DisplayName = "Confirm EmptyListDataLoader works as expected")]
+        public async Task TestEmptyListDataLoader() {
+            var strings = new [] {"item1", "item2", "item3"};
+            var dataLoader = new EmptyListDataLoader();
+
+            var loadTask = Task.WhenAll(dataLoader.LoadAsync(strings));
+            await dataLoader.DispatchAsync();
+            var result = loadTask.Result;
+
+            Assert.Collection(result, m => Assert.True(strings.All(s => m.Contains(s))));
+        }
+        
+        [Fact(DisplayName = "LoadAsync should allow empty lists as parameter")]
+        public async Task AllowEmptyListOnReadOnlyListAsync() {
+            var dataLoader = new EmptyListDataLoader();
+
+            var loadTask = Task.WhenAll(dataLoader.LoadAsync(new List<string>()));
+            await dataLoader.DispatchAsync();
+            var result = loadTask.Result;
+
+            Assert.Collection(result, m => Assert.True(m.Count == 0));
+        }
+        
+        [Fact(DisplayName = "LoadAsync should allow empty lists as parameter")]
+        public async Task AllowEmptyListOnArrayAsync() {
+            var dataLoader = new EmptyListDataLoader();
+
+            var loadTask = Task.WhenAll(dataLoader.LoadAsync(new string[0]));
+            await dataLoader.DispatchAsync();
+            var result = loadTask.Result;
+
+            Assert.Collection(result, m => Assert.True(m.Count == 0));
+        }
+        
         #endregion
     }
 }

--- a/src/Core.Tests/FakeDataLoaders/EmptyListDataLoader.cs
+++ b/src/Core.Tests/FakeDataLoaders/EmptyListDataLoader.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GreenDonut.FakeDataLoaders
+{
+    internal class EmptyListDataLoader
+        : DataLoaderBase<string, string>
+    {
+        protected override async Task<IReadOnlyList<IResult<string>>> Fetch(IReadOnlyList<string> keys)
+        {
+            return await Task.FromResult(keys.Select(k => Result<string>.Resolve(k)).ToList());
+        }
+    }
+}

--- a/src/Core/DataLoaderBase.cs
+++ b/src/Core/DataLoaderBase.cs
@@ -201,12 +201,6 @@ namespace GreenDonut
                 throw new ArgumentNullException(nameof(keys));
             }
 
-            if (keys.Length < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(keys),
-                    "There must be at least one key");
-            }
-
             return LoadInternalAsync(keys);
         }
 
@@ -217,12 +211,6 @@ namespace GreenDonut
             if (keys == null)
             {
                 throw new ArgumentNullException(nameof(keys));
-            }
-
-            if (keys.Count < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(keys),
-                    "There must be at least one key");
             }
 
             return LoadInternalAsync(keys);


### PR DESCRIPTION
In using GreenDonut, we have to constantly check our input lists as to whether they are empty before calling LoadAsync. There's no real reason for this, as the Task created by the LoadAsync method will return a completed Task with an empty response List, exactly as one would expect. Since GreenDonut can handle this case transparently, and there is a clear response type when an empty list of keys is given, pushing that responsibility to the framework rather than the client is preferable. 